### PR TITLE
Develop (#19)

### DIFF
--- a/BBS.Libraries.Emails/EmailBaseModel.cs
+++ b/BBS.Libraries.Emails/EmailBaseModel.cs
@@ -35,5 +35,14 @@ namespace BBS.Libraries.Emails
         public IEmailAddressCollection BccEmailAddressCollection { get; set; }
         public IMailMessageAttachmentCollection Attachments { get; set; }
         public MailPriority Priority { get; set; }
+
+        protected EmailBaseModel()
+        {
+            FromEmailAddress = new EmailAddress();
+            ToEmailAddressCollection = new EmailAddressCollection();
+            CcEmailAddressCollection = new EmailAddressCollection();
+            BccEmailAddressCollection = new EmailAddressCollection();
+            Attachments = new MailMessageAttachmentCollection();
+        }
     }
 }

--- a/UnitTests/BBS.Libraries.UnitTests.General/BBS.Libraries.UnitTests.General.csproj
+++ b/UnitTests/BBS.Libraries.UnitTests.General/BBS.Libraries.UnitTests.General.csproj
@@ -40,12 +40,21 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Data.cs" />
+    <Compile Include="Emails.cs" />
     <Compile Include="Enums.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StatusTracker.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\BBS.Libraries.Contracts\BBS.Libraries.Contracts.csproj">
+      <Project>{65ad0d4e-b8f9-463e-a92a-7021f367de0c}</Project>
+      <Name>BBS.Libraries.Contracts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\BBS.Libraries.Emails\BBS.Libraries.Emails.csproj">
+      <Project>{91a15f13-d1d0-4e55-8f52-8c1e2e744fd2}</Project>
+      <Name>BBS.Libraries.Emails</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\BBS.Libraries.Enums\BBS.Libraries.Enums.csproj">
       <Project>{f9ccc56c-a0cf-4568-a51b-7bfdc8deba65}</Project>
       <Name>BBS.Libraries.Enums</Name>

--- a/UnitTests/BBS.Libraries.UnitTests.General/Emails.cs
+++ b/UnitTests/BBS.Libraries.UnitTests.General/Emails.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BBS.Libraries.Extensions;
+using NUnit.Framework;
+
+namespace BBS.Libraries.UnitTests.General
+{
+    [TestFixture]
+    public class Emails
+    {
+        [Test]
+        public void Emails_Can_Be_Serialized_As_Json()
+        {
+            var mail = new BBS.Libraries.Emails.MailMessage();
+
+            var serializedMessage = "{\"From\":null,\"Sender\":null,\"ReplyToList\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"To\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"CC\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"Bcc\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"Priority\":0,\"DeliveryNotificationOptions\":0,\"Subject\":null,\"SubjectEncoding\":null,\"Headers\":null,\"HeadersEncoding\":null,\"Body\":null,\"BodyEncoding\":null,\"IsBodyHtml\":false,\"Attachments\":{\"$type\":\"BBS.Libraries.Emails.MailMessageAttachmentCollection, BBS.Libraries.Emails\",\"$values\":[]},\"AlternateViews\":[]}";
+
+            var serializedResult = mail.ToJsonString<BBS.Libraries.Emails.MailMessage>();
+
+            Assert.That(serializedResult, Is.EqualTo(serializedMessage));
+        }
+
+        [Test]
+        public void Emails_Can_Be_Deserialized_From_Json()
+        {
+            var mail = new BBS.Libraries.Emails.MailMessage();
+
+            var serializedMessage = "{\"From\":null,\"Sender\":null,\"ReplyToList\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"To\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"CC\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"Bcc\":{\"$type\":\"BBS.Libraries.Emails.EmailAddressCollection, BBS.Libraries.Emails\",\"$values\":[]},\"Priority\":0,\"DeliveryNotificationOptions\":0,\"Subject\":null,\"SubjectEncoding\":null,\"Headers\":null,\"HeadersEncoding\":null,\"Body\":null,\"BodyEncoding\":null,\"IsBodyHtml\":false,\"Attachments\":{\"$type\":\"BBS.Libraries.Emails.MailMessageAttachmentCollection, BBS.Libraries.Emails\",\"$values\":[]},\"AlternateViews\":[]}";
+
+            var deserializedResult = serializedMessage.FromJsonString<BBS.Libraries.Emails.MailMessage>();
+
+            Assert.That(deserializedResult.To, Is.EqualTo(mail.To));
+            Assert.That(deserializedResult.From, Is.EqualTo(mail.From));
+            Assert.That(deserializedResult.Priority, Is.EqualTo(mail.Priority));
+            Assert.That(deserializedResult.AlternateViews, Is.EqualTo(mail.AlternateViews));
+            Assert.That(deserializedResult.Attachments, Is.EqualTo(mail.Attachments));
+            Assert.That(deserializedResult.Bcc, Is.EqualTo(mail.Bcc));
+        }
+
+
+    }
+}


### PR DESCRIPTION
- Remove unused project references and "using" statements
- Update BBS.Libraries.Enums to Razor v3.2.3, to match other projects
- Update all NuGet packages to latest stable version
- Remove all unused "using" statements in solution
- Remove unused "System.Web.Razor" reference from "BBS.Libraries.Enums" project
- Remove redundant parentheses when using object initialization syntax
- Declare all BBS.Libraries.ConsoleAppTests.Email test data in one place
- Moved all BBS.Libraries.ConsoleAppTests.Email test data to a static class
- Reverted NuGet to v2.6.4, since it was breaking the build.
- Updating the license and created a small program to actually do the work
- Unit tests extensions (#8)
- Creating unit tests

Lots of unit tests to resolve #7, tho it's not resolved yet unfortunatly.
- Adding more unit tests for strings and whatnot.  Pretty much have code coverage for Extensions now
- Adding nuget publishing on build (#10)
- First attempt at nuget support

Not quite right
- Adding nuget scripts / bash scripts and testing this stuff out
- Updates to travis and deploying nuget script for testing
- Travis complains about missing yml?
- Versioning, trying to fix 'Skipping a deployment with the script provider because this branch is not permitted'
- Need to fix some of the pack locations
- Pointing the script folder incorrectly (Casing matters)

http://stackoverflow.com/a/1763178
- Trying one more time
- Trying another way
- Deleting version to try to pull from assembly
- Revert "Deleting version to try to pull from assembly"

This reverts commit ef138df26190ae317f943ffe53480fad1ec01e57.
- nuget variables
- Adding build flag and version
- Updating versioning
- Ugh, did something stupid
- Could not find $id$ so fixing it.
- It would help if I saved these files.  I'm going to have to squash these commits apparently...
- Let's try this, shall we?
- Trying one more again
- Path might be wrong?
- Again!  Again!
- Once more
- I can't stand working with bash when I don't know commands
- Did I mess up something on the incrementing?
- SED updates?
- Maybe, maybe maybe ?
- New info suggests I should be not so explicit
- Nuget push
- push nuget
- is this the correct order?
- I believe this will work
- Adding verbosity
- Final try for the night
- Once more, sorry
- Trying one more format before I shrug
- Let's try being explicit
- File does not exist
- Version number variable and adding the rest of the packages
- Version variable not right, hardcoding the pattern for now
- Only allowing builds on master now
- Restricting travis from building on pull requests to master

Should be only tags or whateves
- V1.0 (#11) (#13)
- Remove unused project references and "using" statements
- Update BBS.Libraries.Enums to Razor v3.2.3, to match other projects
- Update all NuGet packages to latest stable version
- Remove all unused "using" statements in solution
- Remove unused "System.Web.Razor" reference from "BBS.Libraries.Enums" project
- Remove redundant parentheses when using object initialization syntax
- Declare all BBS.Libraries.ConsoleAppTests.Email test data in one place
- Moved all BBS.Libraries.ConsoleAppTests.Email test data to a static class
- Reverted NuGet to v2.6.4, since it was breaking the build.
- Updating the license and created a small program to actually do the work
- Unit tests extensions (#8)
- Creating unit tests

Lots of unit tests to resolve #7, tho it's not resolved yet unfortunatly.
- Adding more unit tests for strings and whatnot.  Pretty much have code coverage for Extensions now
- Adding nuget publishing on build (#10)
- First attempt at nuget support

Not quite right
- Adding nuget scripts / bash scripts and testing this stuff out
- Updates to travis and deploying nuget script for testing
- Travis complains about missing yml?
- Versioning, trying to fix 'Skipping a deployment with the script provider because this branch is not permitted'
- Need to fix some of the pack locations
- Pointing the script folder incorrectly (Casing matters)

http://stackoverflow.com/a/1763178
- Trying one more time
- Trying another way
- Deleting version to try to pull from assembly
- Revert "Deleting version to try to pull from assembly"

This reverts commit ef138df26190ae317f943ffe53480fad1ec01e57.
- nuget variables
- Adding build flag and version
- Updating versioning
- Ugh, did something stupid
- Could not find $id$ so fixing it.
- It would help if I saved these files.  I'm going to have to squash these commits apparently...
- Let's try this, shall we?
- Trying one more again
- Path might be wrong?
- Again!  Again!
- Once more
- I can't stand working with bash when I don't know commands
- Did I mess up something on the incrementing?
- SED updates?
- Maybe, maybe maybe ?
- New info suggests I should be not so explicit
- Nuget push
- push nuget
- is this the correct order?
- I believe this will work
- Adding verbosity
- Final try for the night
- Once more, sorry
- Trying one more format before I shrug
- Let's try being explicit
- File does not exist
- Version number variable and adding the rest of the packages
- Version variable not right, hardcoding the pattern for now
- Only allowing builds on master now
- Restricting travis from building on pull requests to master

Should be only tags or whateves
- Found an issue with AppInsights

Wasn't instantiating Telemetry client on previous verison.  Oops
- Fix dependencies (#17)
- Fixing the coupling of the emails, as in #16
- Extending some of the email functionality
- Adding unit tests for Emails and some base class creations
